### PR TITLE
Strip whitespace from headers

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -182,7 +182,7 @@ class MainWindow(QDialog):
         category = self.categorySelectionButtonGroup.checkedButton().text()
         date = [self.dateEdit.date().day(), self.dateEdit.date().month(), self.dateEdit.date().year()]
         weeks = int(self.additionalWeeksEdit.text())
-        header = self.headerLineEdit.text()
+        header = self.headerLineEdit.text().strip()
         image = self.imageUrl.text()
         content = self.contentTextEdit.toPlainText()
 


### PR DESCRIPTION
Downstream services benefit from the assumption of no whitespace in headers. The change should have no negative effects because `strip()` does not affect newline characters in the middle of headers